### PR TITLE
Add a dependency only on the package not on a target

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Add PerfectPython dependency to your Package.swift
 // on target section:
 .target(
 	// name: "your project name",
-	dependencies: ["PerfectPython", "PythonAPI"]),
+	dependencies: ["PerfectPython"]),
 ```
 
 Then import two different libraries into the swift source code:


### PR DESCRIPTION
I had to remove the PythonAPI target to be able to get this to run in my project. Just the package seems to be enough.